### PR TITLE
fix(LicensesReport): proper fallback if no URL is defined for a package

### DIFF
--- a/components/LicensesReport/LicensesReport.astro
+++ b/components/LicensesReport/LicensesReport.astro
@@ -131,14 +131,17 @@ const report = cache[uniqueKey];
           </div>
 
           <div class:list={['td', props.class]} role="cell">
-            <a
-              class:list="[is-external]"
-              href={row.homepage || row.repository.url}
-              target="_blank"
-              rel="noopener nofollow"
-            >
-              {row.homepage || row.repository.url}
-            </a>
+            {row.homepage || row.repository.url
+              ? <a
+                class:list="[is-external]"
+                href={row.homepage || row.repository.url}
+                target="_blank"
+                rel="noopener nofollow"
+              >
+                {row.homepage || row.repository.url}
+              </a>
+              : '-'
+            }
           </div>
         </div>
       ))


### PR DESCRIPTION
Some npm packages in the wild, such as `reading-time`, do not define a repository or homepage, or do not do so properly.

To avoid generating invalid anchor elements with no href attribute in such cases, let's fall back to displaying a "-" text node, as it's already done with the authors column.