### PR TITLE
Fix condition in HoverPrefetch.astro

### DIFF
--- a/app/HoverPrefetch/HoverPrefetch.astro
+++ b/app/HoverPrefetch/HoverPrefetch.astro
@@ -16,7 +16,7 @@ if (typeof props.max !== 'number') {
     if (e.target.tagName === 'A' && prefetchList.length < max) {
       const url = e.target.getAttribute('href');
 
-      if (url.startsWith('/' && url !== window.location.pathname )) {
+      if (url.startsWith('/') && url !== window.location.pathname) {
         if (prefetchList.includes(url) === false) {
           // console.log(`prefetching url ${url}`);
           const link = document.createElement('link');


### PR DESCRIPTION
The condition checking local/internal links is currently broken.  Fixing it, allows for the functionality to work again.