### PR TITLE
docs: Correct Case of LightBox Import Statement

### DIFF
--- a/app/Lightbox/README.md
+++ b/app/Lightbox/README.md
@@ -25,7 +25,7 @@ pnpm i @julian_cataldo/astro-lightbox
 
 ```astro
 ---
-import Lightbox from '@julian_cataldo/astro-lightbox/Lightbox.astro';
+import LightBox from '@julian_cataldo/astro-lightbox/LightBox.astro';
 // ...
 ---
 ```
@@ -34,7 +34,7 @@ import Lightbox from '@julian_cataldo/astro-lightbox/Lightbox.astro';
 <!-- ... -->
 <head>
   <!-- ... -->
-  <Lightbox />
+  <LightBox />
 </head>
 <body>
   <!-- ... -->


### PR DESCRIPTION
This PR addresses a case sensitivity issue that occurs during the build process on AWS Amplify, even though the build succeeds on local macOS machine.
The issue stems from the import statement of `@julian_cataldo/astro-lightbox`, where the file `lightbox.astro` should be correctly referenced as `lightbox.astro`.

While the incorrect case did not cause problems on local macOS machine, it did cause build failures on AWS Amplify, which, like many Linux-based systems, is case-sensitive. (related issue: #83 )

By correcting the case in the import statement, this PR ensures consistent build success across platforms.
It is also suggested that the documentation be updated to reflect this change and prevent similar issues in the future.