### PR TITLE
fix typo

### DIFF
--- a/components/Diagram/README.md
+++ b/components/Diagram/README.md
@@ -10,7 +10,7 @@
 [![EditorConfig](https://img.shields.io/badge/EditorConfig-333333.svg?logo=editorconfig)](https://editorconfig.org)
 [![ESLint](https://img.shields.io/badge/ESLint-3A33D1?logo=eslint)](https://eslint.org)
 
-Embed you Mermaid diagrams in no time inside your Astro templates.  
+Embed your Mermaid diagrams in no time inside your Astro templates.  
 Features **server-side rendering** and **smart caching**.  
 Available as a stand-alone component or as an MDX plugin, replacing `mermaid` code blocks on-the-fly.
 

--- a/components/Diagram/package.json
+++ b/components/Diagram/package.json
@@ -1,7 +1,7 @@
 {
   "name": "astro-diagram",
   "version": "0.7.0",
-  "description": "Embed you Mermaid diagrams inside your Astro templates.\nFeatures server-side rendering and smart caching.",
+  "description": "Embed your Mermaid diagrams inside your Astro templates.\nFeatures server-side rendering and smart caching.",
   "keywords": [
     "astro",
     "astro-component",


### PR DESCRIPTION
I noticed the typo on the main page for Mermaid diagrams in Astro. I guess it pulls from here, but tbh I didn't check

![screenshot 2024-04-30 at 18 12 04@2x](https://github.com/JulianCataldo/web-garden/assets/2641205/10983a0a-77ae-44a2-a582-9f93fca4be6a)
