### PR TITLE
Fix package.json homepage and directory

### DIFF
--- a/app/BaseDocument/package.json
+++ b/app/BaseDocument/package.json
@@ -13,14 +13,14 @@
     "html",
     "document"
   ],
-  "homepage": "https://code.juliancataldo.com/component/astro-base",
+  "homepage": "https://code.juliancataldo.com/component/astro-base-document",
   "bugs": {
     "url": "https://github.com/JulianCataldo/web-garden/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/JulianCataldo/web-garden",
-    "directory": "app/Base"
+    "directory": "app/BaseDocument"
   },
   "license": "ISC",
   "author": "Julian Cataldo",

--- a/app/GoogleAnalytics/package.json
+++ b/app/GoogleAnalytics/package.json
@@ -11,14 +11,14 @@
     "ga4",
     "javascript"
   ],
-  "homepage": "https://code.juliancataldo.com/component/astro-analytics",
+  "homepage": "https://code.juliancataldo.com/component/astro-google-analytics",
   "bugs": {
     "url": "https://github.com/JulianCataldo/web-garden/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/JulianCataldo/web-garden",
-    "directory": "app/Analytics"
+    "directory": "app/GoogleAnalytics"
   },
   "license": "ISC",
   "author": "Julian Cataldo",

--- a/app/PageTransition/package.json
+++ b/app/PageTransition/package.json
@@ -13,14 +13,14 @@
     "links",
     "animation"
   ],
-  "homepage": "https://code.juliancataldo.com/component/astro-transition",
+  "homepage": "https://code.juliancataldo.com/component/astro-page-transition",
   "bugs": {
     "url": "https://github.com/JulianCataldo/web-garden/issues"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/JulianCataldo/web-garden",
-    "directory": "app/Transition"
+    "directory": "app/PageTransition"
   },
   "license": "ISC",
   "author": "Julian Cataldo",


### PR DESCRIPTION
homepage from package.json are used by npmjs.com and astro.build/integrations to link the package to the documentation. Having correct urls helps.